### PR TITLE
admin registration, csv export, and data display table updates

### DIFF
--- a/src/components/DataDisplay/Table.tsx
+++ b/src/components/DataDisplay/Table.tsx
@@ -13,6 +13,7 @@ export interface TableProps extends ComponentPropsWithoutRef<"table"> {
   className?: string;
   formatFunctions?: Record<string, (val: any) => string | ReactElement>;
   actions?: React.ReactNode[] | React.ReactNode;
+  keyLabelMapping?: { [key: string]: string }
 }
 
 export const Table = ({
@@ -21,6 +22,7 @@ export const Table = ({
   className,
   formatFunctions,
   actions = [],
+  keyLabelMapping,
   ...props
 }: TableProps) => {
   const containerStyles = [styles.container];
@@ -39,9 +41,15 @@ export const Table = ({
       <table {...props} className={containerStyles.join(" ")}>
         <thead>
           <tr>
-            {keys.map((key) => (
-              <th key={getKey(key)}>{getKey(key)}</th>
-            ))}
+            {
+              keys.map((key) => {
+                if (keyLabelMapping) {
+                  return <th key={getKey(key)}>{keyLabelMapping[getKey(key)]}</th>
+                } else {
+                  return <th key={getKey(key)}>{getKey(key)}</th>
+                }
+              })
+            }
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
### Admin Registration
- add functionality to add/remove columns from the table view via modal (makes check-in easier for mobile)
- add flag for 21 or older

### Event CSV Export
- add firstEvent column
- add time of registration column
- add checkedIn column
- modify customFields column export

### Data Display Table
- create optional key-label mapping prop 