### PR TITLE
fix for inconsistent customFields existance in sign up form state

### DIFF
--- a/src/app/events/[slug]/registration.tsx
+++ b/src/app/events/[slug]/registration.tsx
@@ -105,6 +105,7 @@ export default function Registration({ event }: { event: Events }) {
           onSubmit={handleRegistrationSubmit}
           values={me} // if we add new fields in the future, autopopulate them for logged in users
           hiddenFields={["user"]}
+          customFields={eventData ? event.customFields: {}} // pass custom fields from event data
           labelOverrides={{
             hasAgreedToTerms: (_) => <Waiver />,
           }}

--- a/src/components/DynamicForm/index.tsx
+++ b/src/components/DynamicForm/index.tsx
@@ -30,6 +30,7 @@ export interface DynamicFormProps {
   values?: Record<string, unknown>;
   hiddenFields?: string[];
   labelOverrides?: Record<string, (label: string) => string | JSX.Element>;
+  customFields?: {[ key: string ]: any},
   isLoading?: boolean;
   isProtected?: boolean;
   hideSubmit?: boolean;
@@ -43,12 +44,14 @@ export const DynamicForm = ({
   values = {},
   hiddenFields = [],
   labelOverrides = {},
+  customFields = {},
   isLoading = false,
   isProtected = false,
   hideSubmit = false,
   submitLabel = "Submit",
   isAdmin = false,
 }: DynamicFormProps) => {
+
   // Derive the initial and empty states so they can be used in the created inputs
   const { initialState } = useMemo(() => {
     const { properties } = entity;
@@ -92,12 +95,29 @@ export const DynamicForm = ({
           break;
         default:
           emptyState[propertyKey] = values[propertyKey] || "";
+          break;
       }
     });
     return { initialState: emptyState };
   }, [entity, values, hiddenFields]);
 
   const [formState, setFormState] = useState(initialState);
+
+  // force custom fields to be in state
+  React.useEffect(() => {
+    if (Object.keys(customFields).length > 0) {
+      const initialCustomFields: { [key: string]: any } = Object.entries(customFields).reduce((obj, [cfKey, cfData]) => {
+        obj[String(cfKey)] = cfData.enum[0];
+        return obj
+      }, Object())
+
+      setFormState((prev) => {
+        return { ...prev, ...initialCustomFields }
+      })
+    }
+  }, [customFields])
+
+  
   const [editingObject, setEditingObject] =
     useState<
       | (Record<string, string | number | boolean> & {


### PR DESCRIPTION
Rather urgent fix for PTT sign-ups. The custom fields are sometimes not in the form state in the signups. There is no clear pattern for when this occurs. This fix passes the customFields object from the eventData on the registration page to the dynamic form and adds them to the state regardless of whether they are already there.