### PR TITLE
change home page to server side rendering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import React from "react";
 import Head from "next/head";
 import { EventCard } from "@/components/Events";
@@ -85,7 +84,8 @@ export default async function Home() {
   const res = await fetch(
     `${
       process.env.NEXT_PUBLIC_API_BASE_URL
-    }/events?limit=6&endTime%5B%24gt%5D=${new Date().toLocaleDateString()}&sort=startTime&order=asc`
+    }/events?limit=6&endTime%5B%24gt%5D=${new Date().toLocaleDateString()}&sort=startTime&order=asc`,
+    { cache: "no-store" }
   );
   const events: SearchEventsApiResponse = await res.json();
 


### PR DESCRIPTION
Changing rendering from client to server for home page. Sometimes there are a rather large number of requests visible in the network tab of dev tools. Creating a state variable for events and setting it inside a useEffect hook on the initial page load with empty dep array causes weird double rendering of page. This is smoother and takes care of the issue. However, I'm not an expert on the next js framework and I don't know if there is another reason for client-side rendering here. 